### PR TITLE
Allow config file path to be set in invocation of Instaphp::Instance()

### DIFF
--- a/config.php
+++ b/config.php
@@ -66,9 +66,11 @@ namespace Instaphp {
          * Singleton method since the SimpleXMLElement class is essentially "sealed"
          * @return Config An instance of the Config object
          */
-        public static function Instance()
+        public static function Instance($file = null)
         {
-            if (static::$file == null)
+            if (is_string($file))
+                static::$file = realpath($file);
+            elseif (static::$file == null)
                 static::$file = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'config.xml';
 
             if (!file_exists(static::$file)) {


### PR DESCRIPTION
Currently, one has to place the config file adjacent to config.php for it to be picked up. This commit permits the file to be placed in any location (and thus versioned correctly), and specified at the invocation of Instaphp::Instance().
