### PR TITLE
Populate AccessToken from proper response variable

### DIFF
--- a/src/Instaphp/Instagram/Users.php
+++ b/src/Instaphp/Instagram/Users.php
@@ -54,7 +54,7 @@ class Users extends Instagram
 		]);
 		if ($response->code == 200) {
 			$res = new Response($response);
-			$this->SetAccessToken($res->data['access_token']);
+			$this->SetAccessToken($res->access_token);
 			$this->user = $res->data['user'];
 			return true;
 		}


### PR DESCRIPTION
Currently, the access token is set from `$res->data['access_token']`, which doesn't actually exist.
