### PR TITLE
fixing the subscription create call

### DIFF
--- a/src/Instaphp/Instagram/Subscriptions.php
+++ b/src/Instaphp/Instagram/Subscriptions.php
@@ -66,7 +66,7 @@ class Subscriptions extends Instagram
 			'aspect' => 'media'
 		];
 		$params = $params + $defaults;
-		return $this->http->Post('/subscriptions/', $params);
+		return $this->Post('/subscriptions', $params);
 	}
 	
 	/**


### PR DESCRIPTION
The parameters must be on the body of the request. Using the `Instagram` post method fixes it.
