### PR TITLE
Updating endpoint access tokens after the class has be initialized

### DIFF
--- a/src/Instaphp/Instaphp.php
+++ b/src/Instaphp/Instaphp.php
@@ -162,7 +162,13 @@ class Instaphp
 	 */
 	public function setAccessToken($access_token)
 	{
-		$this->Users->setAccessToken($access_token);
+		//also needs to update all the endpoints
+
+		foreach(static::$endpoints as $endpoint) {
+			$endpoint->setAccessToken($access_token);
+		}
+
+		$this->config['access_token'] = $access_token;
 	}
 
 	/**

--- a/tests/src/Instaphp/InstaphpTest.php
+++ b/tests/src/Instaphp/InstaphpTest.php
@@ -103,8 +103,16 @@ class InstaphpTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testSetAccessToken()
 	{
-		$this->object->setAccessToken(TEST_ACCESS_TOKEN);
 		$this->assertEquals(TEST_ACCESS_TOKEN, $this->object->getAccessToken());
+		$this->assertEquals(TEST_ACCESS_TOKEN, $this->object->Users->getAccessToken());
+
+		$newAccessToken = '0123456789';
+
+		$this->object->setAccessToken($newAccessToken);
+		$this->assertEquals($newAccessToken, $this->object->getAccessToken());
+		$this->assertEquals($newAccessToken, $this->object->Users->getAccessToken());
+		$this->assertEquals($newAccessToken, $this->object->Tags->getAccessToken());
+
 	}
 
 	/**


### PR DESCRIPTION
The problem is that after the main Instaphp class is initialized, the setAccessToken method doesn't update the access tokens for all the endpoints correctly. This PR makes sure that all current and future endpoints use the new token set by Instaphp::setAccessToken()