### PR TITLE
Add support for Instagram's /media/shortcode/<shortcode> endpoint

### DIFF
--- a/src/Instaphp/Instagram/Instagram.php
+++ b/src/Instaphp/Instagram/Instagram.php
@@ -286,11 +286,14 @@ class Instagram
 	{
 		//$base = 'https://api.instagram.com';
 
-        $path = sprintf('/%s/', $path);
-        $path = preg_replace('/[\/]{2,}/', '/', $path);
+		$path = sprintf('/%s/', $path);
+		$path = preg_replace('/[\/]{2,}/', '/', $path);
 
 		if ($add_version && !preg_match('/^\/v1/', $path))
 			$path = '/v1' . $path;
+
+		// Some endpoints don't respond with a trailing slash
+		$path = rtrim($path, '/');
 
 		return $path;
 	}

--- a/src/Instaphp/Instagram/Media.php
+++ b/src/Instaphp/Instagram/Media.php
@@ -65,6 +65,17 @@ class Media extends Instagram
 	{
 		return $this->Get($this->formatPath('/media/%s', $media_id), $params);
 	}
+
+	/**
+	 * Gets info about a particular media item by its shortcode
+	 * @param string $shortcode The shortcode to fetch
+	 * @param array $params Parameters to pass to API
+	 * @return Response
+	 */
+	public function Shortcode($shortcode, array $params = [])
+	{
+		return $this->Get($this->formatPath('/media/shortcode/%s', $media_id), $params);
+	}
 	
 	/**
 	 * Searches Instagram for media by location/distance. Currently supported

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,4 +34,5 @@ define('TEST_ACCESS_TOKEN', '');
 define('TEST_CLIENT_ID', '');
 define('TEST_CLIENT_SECRET', '');
 define('TEST_MEDIA_ID', '');
+define('TEST_MEDIA_SHORTCODE', '');
 include_once dirname(__DIR__) . '/vendor/autoload.php';

--- a/tests/src/Instaphp/Instagram/MediaTest.php
+++ b/tests/src/Instaphp/Instagram/MediaTest.php
@@ -146,7 +146,17 @@ class MediaTest extends InstagramTest
 		$res = $this->object->Uncomment(TEST_MEDIA_ID, static::$comment_id);
 		$this->assertInstanceOf('\Instaphp\Instagram\Response', $res);
 		$this->assertEquals(200, $res->meta['code']);
+	}
 
+	/**
+	 * @covers Instaphp\Instagram\Media::Shortcode
+	 */
+	public function testShortcode()
+	{
+		$res = $this->object->Shortcode(TEST_MEDIA_SHORTCODE);
+		$this->assertInstanceOf('\Instaphp\Instagram\Response', $res);
+		$this->assertEquals(200, $res->meta['code']);
+		$this->assertNotEmpty($res->data);
 	}
 
 }


### PR DESCRIPTION
This allows accessing images by the shortcode used in the web-interface's URLs. For example, `3XYeQxDvHW` in https://instagram.com/p/3XYeQxDvHW/.

A quirk of this endpoint is that it currently does not support trailing slashes in the URI, so these have been stripped.