### PR TITLE
Catch an Instagram error for an invalid access token (fixed)

### DIFF
--- a/src/Instaphp/Exceptions/OAuthAccessTokenException.php
+++ b/src/Instaphp/Exceptions/OAuthAccessTokenException.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * The MIT License (MIT)
+ * Copyright © 2013 Randy Sesser <randy@instaphp.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * 
+ * @author Randy Sesser <randy@instaphp.com>
+ * @filesource
+ */
+
+namespace Instaphp\Exceptions;
+
+/**
+ * OAuthAccessTokenException
+ * 
+ * An error when trying to use an invalid access_token.
+ *
+ * @author Randy Sesser <randy@instaphp.com>
+ * @license http://instaphp.mit-license.org MIT License 
+ * @package Instaphp
+ * @subpackage Exceptions
+ * @version 2.0-dev
+ */
+
+class OAuthAccessTokenException extends InstagramException { }
+

--- a/src/Instaphp/Instagram/Instagram.php
+++ b/src/Instaphp/Instagram/Instagram.php
@@ -343,6 +343,9 @@ class Instagram
 				case 'OAuthRateLimitException':
 					throw new \Instaphp\Exceptions\OAuthRateLimitException($igresponse->meta['error_message'], $igresponse->meta['code'], $igresponse);
 					break;
+				case 'OAuthAccessTokenException':
+					throw new \Instaphp\Exceptions\OAuthAccessTokenException($igresponse->meta['error_message'], $igresponse->meta['code'], $igresponse);
+					break;
 				case 'APINotFoundError':
 					throw new \Instaphp\Exceptions\APINotFoundError($igresponse->meta['error_message'], $igresponse->meta['code'], $igresponse);
 					break;


### PR DESCRIPTION
Example response (HTTP 400):
    {"meta":{"error_type":"OAuthAccessTokenException","code":400,"error_message":"The access_token provided is invalid."}}