### PR TITLE
Add option to avoid urlencode for POST params & updated testComment

### DIFF
--- a/src/Instaphp/Instagram/Instagram.php
+++ b/src/Instaphp/Instagram/Instagram.php
@@ -212,7 +212,7 @@ class Instagram
 	 */
 	protected function post($path, array $params = [], array $headers = [])
 	{
-        $query = $this->prepare($params);
+        $query = $this->prepare($params,false);
         $response = new Response(500);
         try {
 			$response = $this->http->post($this->buildPath($path), [
@@ -258,10 +258,11 @@ class Instagram
 	/**
 	 * Simply prepares the parameters being passed. Automatically set the client_id
 	 * unless there is an access_token, in which case it is added instead
-	 * @param array $params The list of parameters to perpare for a request
+	 * @param array $params The list of parameters to prepare for a request
+	 * @param bool $encode Whether the params should be urlencoded
 	 * @return array The prepared parameters
 	 */
-	private function prepare(array $params)
+	private function prepare(array $params, $encode = true)
 	{
 		$params['client_id'] = $this->client_id;
 		if (!empty($this->access_token)) {
@@ -269,8 +270,10 @@ class Instagram
 			$params['access_token'] = $this->access_token;
 		}
 
-		foreach ($params as $k => $v) {
-			$params[$k] = urlencode($v);
+		if ($encode) {
+			foreach ($params as $k => $v) {
+				$params[$k] = urlencode($v);
+			}
 		}
 
 		return $params;

--- a/tests/src/Instaphp/Instagram/MediaTest.php
+++ b/tests/src/Instaphp/Instagram/MediaTest.php
@@ -122,8 +122,8 @@ class MediaTest extends InstagramTest
 		$this->assertEquals(200, $res->meta['code']);
 		$this->assertNotEmpty($res->data);
 		$this->assertNotEmpty($res->data['id']);
+		$this->assertSame('Test comment', $res->data['text']);
 		static::$comment_id = $res->data['id'];
-
 	}
 
 	/**


### PR DESCRIPTION
Because it's not needed, but it also meant that previously a comment would be urlencoded when posted on Instagram. 

Added a test for regression.