### PR TITLE
Fixing header capitalisation and some deprecated endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ docs/*
 tmp/*
 composer.lock
 .DS_*
+/tests/bootstrap.private.php
+/tests/src/instagram_test.log
+/tests/instagram_test.log
+/instagram_test.log
+/tests/src/Instaphp/Instagram/instagram_test.log

--- a/src/Instaphp/Instagram/Instagram.php
+++ b/src/Instaphp/Instagram/Instagram.php
@@ -138,6 +138,8 @@ class Instagram
 	    }
 	    
         $emitter->attach(new InstagramSignedAuthEvent($this->client_ip, $this->client_secret));
+
+
 	}
 
 	/**

--- a/src/Instaphp/Instagram/Media.php
+++ b/src/Instaphp/Instagram/Media.php
@@ -45,6 +45,8 @@ namespace Instaphp\Instagram;
 class Media extends Instagram
 {
 	/**
+	 * @deprecated
+	 *
 	 * Gets current popular media
 	 * @param array $params Parameters to pass to API ('count' is the only known 
 	 *                      parameters supported)

--- a/src/Instaphp/Instagram/Response.php
+++ b/src/Instaphp/Instagram/Response.php
@@ -41,12 +41,12 @@ class Response
 	/**
 	 * The HTTP header in the response that holds the rate limit for this request
 	 */
-	const RATE_LIMIT_HEADER = 'X-Ratelimit-Limit';
+	const RATE_LIMIT_HEADER = 'x-ratelimit-limit';
 
 	/**
 	 * The HTTP header in the response that holds the rate limit remaingin
 	 */
-	const RATE_LIMIT_REMAINING_HEADER = 'X-Ratelimit-Remaining';
+	const RATE_LIMIT_REMAINING_HEADER = 'x-ratelimit-remaining';
 
 	/** @var string The request url */
 	public $url = '';

--- a/src/Instaphp/Instagram/Users.php
+++ b/src/Instaphp/Instagram/Users.php
@@ -106,6 +106,7 @@ class Users extends Instagram
 	}
 
 	/**
+	 * @deprecated
 	 * Gets the currently authenticated user's feed
 	 * @param array $params Parameters to pass to the API
 	 * @return \Instaphp\Instagram\Response

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -35,4 +35,6 @@ define('TEST_CLIENT_ID', '');
 define('TEST_CLIENT_SECRET', '');
 define('TEST_MEDIA_ID', '');
 define('TEST_MEDIA_SHORTCODE', '');
+define('TEST_COMMENTS', false);
+define('TEST_LIKES', false);
 include_once dirname(__DIR__) . '/vendor/autoload.php';

--- a/tests/src/Instaphp/Instagram/InstagramTest.php
+++ b/tests/src/Instaphp/Instagram/InstagramTest.php
@@ -24,7 +24,7 @@ class InstagramTest extends \PHPUnit_Framework_TestCase
 		'api_version' => 'v1',
 		'client_id' => TEST_CLIENT_ID,
 		'client_secret' => TEST_CLIENT_SECRET,
-		'access_token' => '',
+		'access_token' => TEST_ACCESS_TOKEN,
 		'redirect_uri' => '',
 		'http_useragent' => 'Instaphp/Guzzle/cUrl v3 (+http://instaphp.com)',
 		'http_timeout' => 6,

--- a/tests/src/Instaphp/Instagram/LocationsTest.php
+++ b/tests/src/Instaphp/Instagram/LocationsTest.php
@@ -13,8 +13,17 @@ class LocationsTest extends InstagramTest
 	 * @var Locations
 	 */
 	protected $object;
-	
+
+	/**
+	 * @deprecated
+	 * @var string
+	 */
 	protected $foursquarev2id = '4e239487d4c0d32591045a8e';
+
+	/**
+	 * @var string
+	 */
+	protected $facebookPlacesId = '165461756803348';
 	
 	protected $location_id = '3143441';
 	
@@ -54,7 +63,7 @@ class LocationsTest extends InstagramTest
 		$this->assertInstanceOf('\Instaphp\Instagram\Response', $res);
 		$this->assertNotEmpty($res->data);
 		$this->assertGreaterThan(0, count($res->data));
-		$this->assertEquals('Green Flash Brewing Company', $res->data['name']);
+		$this->assertEquals('Green Flash Brewing Co.', $res->data['name']);
 	}
 
 	/**
@@ -74,7 +83,7 @@ class LocationsTest extends InstagramTest
 	 */
 	public function testSearch()
 	{
-		$res = $this->object->Search(['count' => 10, 'foursquare_v2_id' => $this->foursquarev2id]);
+		$res = $this->object->Search(['count' => 10, 'facebook_places_id' => $this->facebookPlacesId]);
 		$this->assertInstanceOf('\Instaphp\Instagram\Response', $res);
 		$this->assertNotEmpty($res->data);
 		$res = $this->object->Search(['lat' => $this->lat, 'lng' => $this->lng]);

--- a/tests/src/Instaphp/Instagram/MediaTest.php
+++ b/tests/src/Instaphp/Instagram/MediaTest.php
@@ -39,20 +39,6 @@ class MediaTest extends InstagramTest
 	}
 
 	/**
-	 * @covers Instaphp\Instagram\Media::Popular
-	 */
-	public function testPopular()
-	{
-		$res = $this->object->Popular(['count' => 5]);
-		$this->assertInstanceOf('\Instaphp\Instagram\Response', $res);
-		$this->assertEquals(200, $res->meta['code']);
-		$this->assertNotEmpty($res->data);
-		$this->assertEquals(5, count($res->data));
-		$this->assertEquals(5000, $res->limit);
-		$this->assertLessThan($res->limit, $res->remaining);
-	}
-
-	/**
 	 * @covers Instaphp\Instagram\Media::Info
 	 */
 	public function testInfo()
@@ -80,6 +66,9 @@ class MediaTest extends InstagramTest
 	 */
 	public function testLike()
 	{
+		if(TEST_LIKES === false) {
+			$this->markTestSkipped('Likes not tested');
+		}
 		$this->object->SetAccessToken(TEST_ACCESS_TOKEN);
 		$res = $this->object->Like(TEST_MEDIA_ID);
 		$this->assertInstanceOf('\Instaphp\Instagram\Response', $res);
@@ -93,6 +82,9 @@ class MediaTest extends InstagramTest
 	 */
 	public function testLikes()
 	{
+		if(TEST_LIKES === false) {
+			$this->markTestSkipped('Likes not tested');
+		}
 		$res = $this->object->Likes(TEST_MEDIA_ID);
 		$this->assertInstanceOf('\Instaphp\Instagram\Response', $res);
 		$this->assertEquals(200, $res->meta['code']);
@@ -103,6 +95,9 @@ class MediaTest extends InstagramTest
 	 */
 	public function testUnlike()
 	{
+		if(TEST_LIKES === false) {
+			$this->markTestSkipped('Likes not tested');
+		}
 		$this->object->SetAccessToken(TEST_ACCESS_TOKEN);
 		$res = $this->object->Unlike(TEST_MEDIA_ID);
 		$this->assertInstanceOf('\Instaphp\Instagram\Response', $res);
@@ -116,6 +111,9 @@ class MediaTest extends InstagramTest
 	 */
 	public function testComment()
 	{
+		if(TEST_COMMENTS === false) {
+			$this->markTestSkipped('Comments not tested');
+		}
 		$this->object->SetAccessToken(TEST_ACCESS_TOKEN);
 		$res = $this->object->Comment(TEST_MEDIA_ID, 'Test comment');
 		$this->assertInstanceOf('\Instaphp\Instagram\Response', $res);
@@ -131,6 +129,9 @@ class MediaTest extends InstagramTest
 	 */
 	public function testComments()
 	{
+		if(TEST_COMMENTS === false) {
+			$this->markTestSkipped('Comments not tested');
+		}
 		$res = $this->object->Comments(TEST_MEDIA_ID);
 		$this->assertInstanceOf('\Instaphp\Instagram\Response', $res);
 		$this->assertEquals(200, $res->meta['code']);
@@ -142,9 +143,14 @@ class MediaTest extends InstagramTest
 	 */
 	public function testUncomment()
 	{
+		if(TEST_COMMENTS === false) {
+			$this->markTestSkipped('Comments not tested');
+		}
 		$this->object->SetAccessToken(TEST_ACCESS_TOKEN);
 		$res = $this->object->Uncomment(TEST_MEDIA_ID, static::$comment_id);
 		$this->assertInstanceOf('\Instaphp\Instagram\Response', $res);
+
+		$this->assertArrayHasKey('code', (array) $res->meta);
 		$this->assertEquals(200, $res->meta['code']);
 	}
 

--- a/tests/src/Instaphp/Instagram/UsersTest.php
+++ b/tests/src/Instaphp/Instagram/UsersTest.php
@@ -49,28 +49,6 @@ class UsersTest extends InstagramTest
 		$this->assertEquals('bowkylion', $res->data['username']);
     }
 
-	/**
-	 * @covers Instaphp\Instagram\Users::Feed
-	 * @expectedException \Instaphp\Exceptions\OAuthParameterException
-	 */
-	public function testFeedException()
-	{
-		$res = $this->object->Feed(["count" => 1]);
-	}
-
-    /**
-     * @covers Instaphp\Instagram\Users::Feed
-     */
-    public function testFeed()
-    {
-		$this->object->SetAccessToken(TEST_ACCESS_TOKEN);
-		$res = $this->object->Feed(["count" => 5]);
-		$this->assertNotEmpty($res->data);
-		$this->assertEquals(200, $res->meta['code']);
-		$this->assertEquals(5, count($res->data));
-
-    }
-
     /**
      * @covers Instaphp\Instagram\Users::Recent
      */
@@ -89,6 +67,9 @@ class UsersTest extends InstagramTest
 	 */
 	public function testLikedException()
 	{
+        if(TEST_LIKES === false) {
+            $this->markTestSkipped('Likes not tested');
+        }
 		$res = $this->object->Liked();
 	}
 
@@ -97,6 +78,9 @@ class UsersTest extends InstagramTest
      */
     public function testLiked()
     {
+        if(TEST_LIKES === false) {
+            $this->markTestSkipped('Likes not tested');
+        }
 		$this->object->SetAccessToken(TEST_ACCESS_TOKEN);
 		$res = $this->object->Liked(["count" => 1]);
 		$this->assertNotEmpty($res->data);


### PR DESCRIPTION
Instagram have helpfully changed their headers to lowercase which is causing some issues for us.

I've also updated some of the tests and @deprecated some of the methods