### PR TITLE
Handling APIAgeGatedError and gracefully handling invalid response format

### DIFF
--- a/src/Instaphp/Exceptions/APIAgeGatedError.php
+++ b/src/Instaphp/Exceptions/APIAgeGatedError.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * The MIT License (MIT)
+ * Copyright © 2013 Randy Sesser <randy@instaphp.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * 
+ * @author Randy Sesser <randy@instaphp.com>
+ * @filesource
+ */
+
+namespace Instaphp\Exceptions;
+
+/**
+ * APIAgeGatedError
+ * 
+ * Exception thrown when user cannot view some resource due to unclear reasons
+ *
+ * @author Randy Sesser <randy@instaphp.com>
+ * @license http://instaphp.mit-license.org MIT License 
+ * @package Instaphp
+ * @subpackage Exceptions
+ * @version 2.0-dev
+ */
+class APIAgeGatedError extends InstagramException { }
+

--- a/src/Instaphp/Exceptions/InvalidResponseFormatException.php
+++ b/src/Instaphp/Exceptions/InvalidResponseFormatException.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * The MIT License (MIT)
+ * Copyright © 2013 Randy Sesser <randy@instaphp.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * 
+ * @author Randy Sesser <randy@instaphp.com>
+ * @filesource
+ */
+
+namespace Instaphp\Exceptions;
+
+/**
+ * InvalidResponseFormatException
+ * 
+ * Used GuzzleHttp\Exception\ParseException which is thrown when response body is not valid JSON.
+ * 
+ * @author Randy Sesser <randy@instaphp.com>
+ * @license http://instaphp.mit-license.org MIT License 
+ * @package Instaphp
+ * @subpackage Exceptions
+ * @version 2.0-dev
+ */
+class InvalidResponseFormatException extends InstagramException { }
+

--- a/src/Instaphp/Instagram/Instagram.php
+++ b/src/Instaphp/Instagram/Instagram.php
@@ -360,6 +360,9 @@ class Instagram
 				case 'APIInvalidParametersError':
 					throw new \Instaphp\Exceptions\APIInvalidParametersError($igresponse->meta['error_message'], $igresponse->meta['code'], $igresponse);
 					break;
+				case 'APIAgeGatedError':
+					throw new \Instaphp\Exceptions\APIAgeGatedError($igresponse->meta['error_message'], $igresponse->meta['code'], $igresponse);
+					break;
 				default:
 					break;
 			}

--- a/src/Instaphp/Instagram/Instagram.php
+++ b/src/Instaphp/Instagram/Instagram.php
@@ -28,6 +28,7 @@
 
 namespace Instaphp\Instagram;
 
+use GuzzleHttp\Exception\ParseException;
 use GuzzleHttp\Exception\RequestException;
 use Instaphp\Exceptions\Exception as InstaphpException;
 use GuzzleHttp\Client;
@@ -336,7 +337,11 @@ class Instagram
 		if ($response == NULL)
 			throw new \Instaphp\Exceptions\Exception("Response object is NULL");
 
-		$igresponse = new \Instaphp\Instagram\Response($response);
+        try {
+		    $igresponse = new \Instaphp\Instagram\Response($response);
+        } catch (ParseException $e) {
+            throw new \Instaphp\Exceptions\InvalidResponseFormatException($e->getMessage(), $e->getCode(), null, $e);
+        }
 
 		//-- First check if there's an API error from the Instagram response
 		if (isset($igresponse->meta['error_type'])) {

--- a/tests/src/Instaphp/Instagram/ErrorsTest.php
+++ b/tests/src/Instaphp/Instagram/ErrorsTest.php
@@ -6,7 +6,7 @@ include_once 'InstagramTest.php';
 use GuzzleHttp\Event\CompleteEvent;
 use GuzzleHttp\Stream\Stream;
 
-class ExceptionsTest extends InstagramTest
+class ErrorsTest extends InstagramTest
 {
     /**
      * @var Instagram
@@ -38,7 +38,7 @@ class ExceptionsTest extends InstagramTest
     }
 
     /**
-     * @covers \Instaphp\Exceptions\APIAgeGatedError
+     * @covers \Instaphp\Instagram\Instagram:parseResponse
      * @expectedException \Instaphp\Exceptions\APIAgeGatedError
      */
     public function testAPIAgeGatedError()
@@ -47,10 +47,19 @@ class ExceptionsTest extends InstagramTest
 
         $this->object = new Users($this->config);
 
-        $this->object->SetAccessToken(TEST_ACCESS_TOKEN);
         $res = $this->object->Recent(5830, ["count" => 5]);
-        $this->assertNotEmpty($res->data);
-        $this->assertEquals(200, $res->meta['code']);
-        $this->assertEquals(5, count($res->data));
+    }
+
+    /**
+     * @covers \Instaphp\Instagram\Instagram:parseResponse
+     * @expectedException \Instaphp\Exceptions\InvalidResponseFormatException
+     */
+    public function testHTMLPageNotFoundError()
+    {
+        $this->mockResponse(404, '<html><body>Page not found stub</body></html>', 'text/html');
+
+        $this->object = new Users($this->config);
+
+        $res = $this->object->Recent(5830, ["count" => 5]);
     }
 }

--- a/tests/src/Instaphp/Instagram/ExceptionsTest.php
+++ b/tests/src/Instaphp/Instagram/ExceptionsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Instaphp\Instagram;
+include_once 'InstagramTest.php';
+
+use GuzzleHttp\Event\CompleteEvent;
+use GuzzleHttp\Stream\Stream;
+
+class ExceptionsTest extends InstagramTest
+{
+    /**
+     * @var Instagram
+     */
+    protected $object;
+
+    /**
+     * Swaps Instagram response with new one.
+     * Easiest way of mocking responses without changing Instaphp source code.
+     *
+     * @param int         $statusCode
+     * @param string|null $body
+     * @param string|null $contentType
+     */
+    protected function mockResponse($statusCode, $body = null, $contentType = null)
+    {
+        $this->config['event.after'] = function (CompleteEvent $event) use ($statusCode, $body, $contentType) {
+            $response = $event->getResponse();
+            $response->setStatusCode($statusCode);
+
+            if (!is_null($body)) {
+                $response->setBody(Stream::factory($body));
+            }
+
+            if (!is_null($contentType)) {
+                $response->setHeader('content-type', $contentType);
+            }
+        };
+    }
+
+    /**
+     * @covers \Instaphp\Exceptions\APIAgeGatedError
+     * @expectedException \Instaphp\Exceptions\APIAgeGatedError
+     */
+    public function testAPIAgeGatedError()
+    {
+        $this->mockResponse(400, '{"meta": {"error_type": "APIAgeGatedError", "code": 400, "error_message": "you cannot view this resource"}}');
+
+        $this->object = new Users($this->config);
+
+        $this->object->SetAccessToken(TEST_ACCESS_TOKEN);
+        $res = $this->object->Recent(5830, ["count" => 5]);
+        $this->assertNotEmpty($res->data);
+        $this->assertEquals(200, $res->meta['code']);
+        $this->assertEquals(5, count($res->data));
+    }
+}


### PR DESCRIPTION
Instagram started responding with new `APIAgeGatedError`, so I've added new type of `InstagramException`. 

Also we're receiving HTML 404 errors in API response from time to time which effects in raising `GuzzleHttp\Exception\ParseException`. I've added try ... catch block over Response constructor to catch parse errors and rethrow them as new `InvalidResponseFormatException`.