### PR TITLE
Added getters for useful config properties

### DIFF
--- a/src/Instaphp/Instaphp.php
+++ b/src/Instaphp/Instaphp.php
@@ -197,4 +197,28 @@ class Instaphp
     {
         return $this->Users->getCurrentUser();
     }
+
+    /**
+     * @return string
+     */
+    public function getClientId()
+    {
+        return $this->config['client_id'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getClientSecret()
+    {
+        return $this->config['client_secret'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getRedirectUri()
+    {
+        return $this->config['redirect_uri'];
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,6 +33,7 @@ define('TEST_ROOT', dirname(__DIR__) . '/tests');
 define('TEST_ACCESS_TOKEN', '');
 define('TEST_CLIENT_ID', '');
 define('TEST_CLIENT_SECRET', '');
+define('TEST_REDIRECT_URI', 'http://test.com/redirect');
 define('TEST_MEDIA_ID', '');
 define('TEST_MEDIA_SHORTCODE', '');
 define('TEST_COMMENTS', false);

--- a/tests/src/Instaphp/InstaphpTest.php
+++ b/tests/src/Instaphp/InstaphpTest.php
@@ -21,7 +21,7 @@ class InstaphpTest extends \PHPUnit_Framework_TestCase
 		'client_id' => TEST_CLIENT_ID,
 		'client_secret' => TEST_CLIENT_SECRET,
 		'access_token' => '',
-		'redirect_uri' => '',
+		'redirect_uri' => TEST_REDIRECT_URI,
 		'http_useragent' => 'Instaphp/Guzzle/cUrl v3 (+http://instaphp.com)',
 		'http_timeout' => 6,
 		'http_connect_timeout' => 2,
@@ -126,4 +126,33 @@ class InstaphpTest extends \PHPUnit_Framework_TestCase
 		$this->assertTrue($this->object->isAuthorized());
 	}
 
+    /**
+     * @covers Instaphp\Instaphp::getClientId
+     */
+    public function testGetClientId()
+    {
+        $id = $this->object->getClientId();
+
+        $this->assertEquals($id, TEST_CLIENT_ID);
+	}
+
+    /**
+     * @covers Instaphp\Instaphp::getClientSecret
+     */
+    public function testGetClientSecret()
+    {
+        $id = $this->object->getClientSecret();
+
+        $this->assertEquals($id, TEST_CLIENT_SECRET);
+    }
+
+    /**
+     * @covers Instaphp\Instaphp::getRedirectUri
+     */
+    public function testGetRedirectUri()
+    {
+        $id = $this->object->getRedirectUri();
+
+        $this->assertEquals($id, TEST_REDIRECT_URI);
+    }
 }


### PR DESCRIPTION
This allows us to handle user-level auth across multiple app instances, as client_id, client_secret and redirect_uri are required to get an access_token from a user auth code.